### PR TITLE
Fix kernel.dart to return x86_64 for amd64 (Windows)

### DIFF
--- a/lib/src/platform/kernel.dart
+++ b/lib/src/platform/kernel.dart
@@ -220,6 +220,7 @@ final processorToArchitecure = <String, ProcessorArchitecture>{
 // 'unicore32'
   'i386': ProcessorArchitecture.x86,
   'i686': ProcessorArchitecture.x86,
+  'amd64': ProcessorArchitecture.x86_64,
   'x86_64': ProcessorArchitecture.x86_64
 // 'xtensa'
 };


### PR DESCRIPTION
Return x86_64 for amd64 (Windows)